### PR TITLE
Make examples in README a little more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,15 @@ URLs have the formats:
 
 ## Demos
 
+`<img src="https://v1.opengraph.11ty.dev/https%3A%2F%2Fwww.netlify.com/small/" alt="OpenGraph Image for netlify.com">`
+
 <img src="https://v1.opengraph.11ty.dev/https%3A%2F%2Fwww.netlify.com/small/" alt="OpenGraph Image for netlify.com">
 
+`<img src="https://v1.opengraph.11ty.dev/https%3A%2F%2Fwww.11ty.dev/small/" alt="OpenGraph Image for 11ty.dev">`
+
 <img src="https://v1.opengraph.11ty.dev/https%3A%2F%2Fwww.11ty.dev/small/" alt="OpenGraph Image for 11ty.dev">
+
+`<img src="https://v1.opengraph.11ty.dev/https%3A%2F%2Fwww.zachleat.com/small/" alt="OpenGraph Image for zachleat.com">`
 
 <img src="https://v1.opengraph.11ty.dev/https%3A%2F%2Fwww.zachleat.com/small/" alt="OpenGraph Image for zachleat.com">
 


### PR DESCRIPTION
The examples in the readme are great - but unless you are looking at the raw markdown it was a little unclear what HTML was producing the images.

Added the example code with wrapping ticks for clarity.

Perhaps helpful for #4 