### PR TITLE
Fixes #6, missing YouTube images

### DIFF
--- a/ogImageHtml.js
+++ b/ogImageHtml.js
@@ -21,12 +21,7 @@ class OgImageHtml {
   }
 
   async fetch() {
-    let response = await fetch(this.url, {
-      referrer: "",
-      headers: {
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
-      }
-    });
+    let response = await fetch(this.url);
     let body = await response.text();
     this.body = body;
 
@@ -73,7 +68,6 @@ class OgImageHtml {
       }
     }
 
-    console.log( "Found:", Array.from(results) );
     return Array.from(results);
   }
 

--- a/ogImageHtml.js
+++ b/ogImageHtml.js
@@ -28,10 +28,10 @@ class OgImageHtml {
       }
     });
     let body = await response.text();
-    console.log( body.split("<meta ").slice(1).map(line => `<meta ${line.slice(0, 200)}`) );
     this.body = body;
 
     this.$ = cheerio.load(body);
+
     return body;
   }
 
@@ -41,30 +41,40 @@ class OgImageHtml {
   }
 
   findImageUrls() {
-    let results = [];
-    let ogImageSecure = this.$("meta[name='og:image:secure_url']").attr("content");
+    let results = new Set();
 
-    if(ogImageSecure) {
-      results.push(ogImageSecure);
+    let cases = [
+      ["meta[name='og:image:secure_url']", "content"],
+      ["meta[name='og:image']", "content"],
+      ["meta[property='og:image']", "content"], // not sure if this is standardized
+      ["meta[name='twitter:image']", "content"],
+
+      // YouTube specific: https://github.com/11ty/api-opengraph-image/issues/6
+      ["link[rel='image_src']", "href"],
+      ["link[itemprop='thumbnailUrl']", "href"],
+      // ["link[itemprop='url']", "href"],
+    ];
+
+    for(let [selector, attribute] of cases) {
+      let imageUrl = this.$(selector).attr(attribute);
+      if(imageUrl) {
+        results.add(imageUrl);
+      }
     }
 
-    let ogImage = this.$("meta[name='og:image']").attr("content");
-    if(ogImage) {
-      results.push(ogImage);
+    // More YouTube specific stuff: https://github.com/11ty/api-opengraph-image/issues/6
+    let u = new URL(this.url);
+    if(results.size === 0 && u.host.endsWith(".youtube.com")) {
+      // Sizes borrowed from https://paulirish.github.io/lite-youtube-embed/testpage/poster-image-availability.html
+      // let sizes = ["maxresdefault", "sddefault", "hqdefault", "mqdefault", "default"];
+      let videoId = u.searchParams.get("v");
+      if(videoId) {
+        results.add(`https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`);
+      }
     }
 
-    // not sure if this is standardized or not
-    let ogImageProp = this.$("meta[property='og:image']").attr("content");
-    if(ogImageProp) {
-      results.push(ogImageProp);
-    }
-
-    let twitterImage = this.$("meta[name='twitter:image']").attr("content");
-    if(twitterImage) {
-      results.push(twitterImage);
-    }
-
-    return results;
+    console.log( "Found:", Array.from(results) );
+    return Array.from(results);
   }
 
   async getImages() {

--- a/ogImageHtml.js
+++ b/ogImageHtml.js
@@ -1,5 +1,4 @@
-import fetch from "node-fetch";
-import cheerio from "cheerio";
+import * as cheerio from 'cheerio';
 import EleventyImage from "@11ty/eleventy-img";
 
 class OgImageHtml {
@@ -22,7 +21,11 @@ class OgImageHtml {
   }
 
   async fetch() {
-    let response = await fetch(this.url);
+    let response = await fetch(this.url, {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
+      }
+    });
     let body = await response.text();
     this.body = body;
 

--- a/ogImageHtml.js
+++ b/ogImageHtml.js
@@ -22,11 +22,13 @@ class OgImageHtml {
 
   async fetch() {
     let response = await fetch(this.url, {
+      referrer: "",
       headers: {
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
       }
     });
     let body = await response.text();
+    console.log( body.split("<meta ").slice(1).map(line => `<meta ${line.slice(0, 200)}`) );
     this.body = body;
 
     this.$ = cheerio.load(body);

--- a/package.json
+++ b/package.json
@@ -25,10 +25,9 @@
   "homepage": "https://github.com/11ty/indieweb-avatar#readme",
   "dependencies": {
     "@11ty/eleventy-img": "5.0.0-beta.6",
-    "cheerio": "^1.0.0-rc.12",
-    "node-fetch": "^3.3.2"
+    "cheerio": "^1.0.0"
   },
   "devDependencies": {
-    "vercel": "^35.0.3"
+    "vercel": "^37.1.2"
   }
 }


### PR DESCRIPTION
Turns out we don’t strictly _need_ the metadata for a YouTube URL, we can use the somewhat stable poster url structure hinted at here: https://paulirish.github.io/lite-youtube-embed/testpage/poster-image-availability.html