### PR TITLE
Update package name and URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "eleventy-api-indieweb-avatar",
+  "name": "@11ty/api-opengraph-image",
   "version": "1.0.0",
-  "description": "A runtime service to extract avatar images from the HTML on a web site.",
+  "description": "A runtime service to extract OpenGraph images from the HTML on a web site.",
   "scripts": {
     "start": "npx vercel dev"
   },
@@ -10,7 +10,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/11ty/indieweb-avatar.git"
+    "url": "git+https://github.com/11ty/api-opengraph-image.git"
   },
   "author": {
     "name": "Zach Leatherman",
@@ -19,9 +19,9 @@
   },
   "keywords": [],
   "bugs": {
-    "url": "https://github.com/11ty/indieweb-avatar/issues"
+    "url": "https://github.com/11ty/api-opengraph-image/issues"
   },
-  "homepage": "https://github.com/11ty/indieweb-avatar#readme",
+  "homepage": "https://github.com/11ty/api-opengraph-image#readme",
   "dependencies": {
     "@11ty/eleventy-img": "^6.0.1",
     "cheerio": "^1.0.0"


### PR DESCRIPTION
I installed this package to use its OG extraction code in my Eleventy site. After running,

```
npm i --save-dev https://github.com/11ty/api-opengraph-image
```

the package showed up in my package.json named `eleventy-api-indieweb-avatar` - but this is `api-opengraph-image`.

So here's a wee PR to update some details to this package.

Note that I added the `@11ty` namespace to the start, hope that's good and normal!